### PR TITLE
feat: added pwa implementation to other screens of the project

### DIFF
--- a/src/app/home/escalas/page.tsx
+++ b/src/app/home/escalas/page.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { useEffect, useState } from "react";
-import { CircleMinus, X } from "lucide-react";
+import { CircleMinus, X, WifiOff } from "lucide-react";
 import { AppSidebar } from "@/components/app-sidebar";
 import { deleteMethod, getMethod } from "@/lib/apiRequests";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
@@ -33,6 +33,23 @@ export default function Home() {
 	const [levitasDisponiveis, setLevitasDisponiveis] = useState<Levita[] | undefined>(undefined);
 
 	const [isLeader, setLeader] = useState(false)
+	const [isOffline, setIsOffline] = useState(false)
+
+	useEffect(() => {
+		const handleOnline = () => setIsOffline(false);
+		const handleOffline = () => setIsOffline(true);
+
+		if (typeof window !== 'undefined') {
+			setIsOffline(!navigator.onLine);
+			window.addEventListener('online', handleOnline);
+			window.addEventListener('offline', handleOffline);
+
+			return () => {
+				window.removeEventListener('online', handleOnline);
+				window.removeEventListener('offline', handleOffline);
+			};
+		}
+	}, []);
 
 	useEffect(() => {
 		if (sessionStorage.getItem("role") == "Líder" || sessionStorage.getItem("role") == "ADMIN") {
@@ -70,9 +87,15 @@ export default function Home() {
 				<nav className="mb-4">
 					<div className="flex flex-wrap md:flex-nowrap justify-between items-center">
 						<div className="flex items-center justify-between w-full">
-							<div className="flex items-center">
+							<div className="flex items-center flex-wrap">
 								<BackButton />
 								<h1 className="ml-4 font-extrabold tracking-tight text-2xl sm:text-5xl">Escalas</h1>
+								{isOffline && Array.isArray(escalasData) && escalasData.length > 0 && (
+									<Badge variant="destructive" className="ml-4 mt-2 sm:mt-0 flex gap-1 items-center bg-red-500 hover:bg-red-600 cursor-default">
+										<WifiOff className="w-3 h-3" />
+										Dessincronizado
+									</Badge>
+								)}
 							</div>
 							<SidebarTrigger className="border sm:hidden" />
 						</div>
@@ -102,7 +125,19 @@ export default function Home() {
 							onClick={() => setEspecialFilter(!especialFilter)} disabled={isLoading}>Especiais</Button>
 					</div>
 
-					{Array.isArray(filteredEscalas) && filteredEscalas.length === 0 ? (
+					{isOffline && !escalasData ? (
+						<Card className="text-center border-red-900/20 bg-red-500/5 mt-4">
+							<CardHeader className="items-center">
+								<WifiOff className="h-16 w-16 text-red-500/80 mb-4" />
+								<CardTitle className="text-2xl text-red-500">Sem Conexão</CardTitle>
+							</CardHeader>
+							<CardContent>
+								<p className="text-zinc-500 dark:text-zinc-400 pb-6 text-lg px-4 md:px-10">
+									Você está offline e não possui escalas salvas em cache. Conecte-se à internet para visualizar as escalas.
+								</p>
+							</CardContent>
+						</Card>
+					) : Array.isArray(filteredEscalas) && filteredEscalas.length === 0 ? (
 						<Card className="text-center">
 							<p className="p-6 sm:p-10 text-lg sm:text-2xl text-zinc-400/80">
 								{

--- a/src/app/home/instrumentos/page.tsx
+++ b/src/app/home/instrumentos/page.tsx
@@ -8,11 +8,30 @@ import { useEffect, useState } from "react";
 import BackButton from "@/components/next-back";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/app-sidebar";
+import { Badge } from "@/components/ui/badge";
+import { WifiOff } from "lucide-react";
 
 export default function Home() {
 	const [isLoading, setLoading] = useState(true)
 	const [instrumentosData, setInstrumentosData] = useState<Instrumento[] | undefined>(undefined)
 	const [isLeader, setLeader] = useState(false)
+	const [isOffline, setIsOffline] = useState(false)
+
+	useEffect(() => {
+		const handleOnline = () => setIsOffline(false);
+		const handleOffline = () => setIsOffline(true);
+
+		if (typeof window !== 'undefined') {
+			setIsOffline(!navigator.onLine);
+			window.addEventListener('online', handleOnline);
+			window.addEventListener('offline', handleOffline);
+
+			return () => {
+				window.removeEventListener('online', handleOnline);
+				window.removeEventListener('offline', handleOffline);
+			};
+		}
+	}, []);
 
 	useEffect(() => {
 		if (sessionStorage.getItem("role") == "Líder" || sessionStorage.getItem("role") == "ADMIN") {
@@ -36,9 +55,15 @@ export default function Home() {
 				<nav className="mb-4">
 					<div className="flex items-center mb-4 gap-4 justify-between align-middle">
 						<div className="flex items-center justify-between w-full">
-							<div className="flex items-center">
+							<div className="flex items-center flex-wrap">
 								<BackButton />
 								<h1 className="ml-4 font-extrabold tracking-tight text-2xl sm:text-5xl">Instrumentos</h1>
+								{isOffline && Array.isArray(instrumentosData) && instrumentosData.length > 0 && (
+									<Badge variant="destructive" className="ml-4 mt-2 sm:mt-0 flex gap-1 items-center bg-red-500 hover:bg-red-600 cursor-default">
+										<WifiOff className="w-3 h-3" />
+										Dessincronizado
+									</Badge>
+								)}
 							</div>
 							<SidebarTrigger className="border sm:hidden" />
 						</div>
@@ -52,26 +77,38 @@ export default function Home() {
 				</nav>
 
 
-				<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
-					{isLoading || !instrumentosData ? (
-						<div className="col-span-4 h-full flex items-center justify-center mt-20">
-							<div className="size-80 border-4 border-transparent text-primary/40 text-4xl animate-spin flex items-center justify-center border-t-primary rounded-full">
-								<div className="size-64 border-4 border-transparent text-subprimary/40 text-2xl animate-spin flex items-center justify-center border-t-subprimary rounded-full" />
-							</div>
+				{isOffline && !instrumentosData ? (
+					<Card className="text-center border-red-900/20 bg-red-500/5 mt-4">
+						<div className="p-6 sm:p-10 flex flex-col items-center">
+							<WifiOff className="h-16 w-16 text-red-500/80 mb-4" />
+							<h3 className="text-2xl text-red-500 font-bold mb-2">Sem Conexão</h3>
+							<p className="text-zinc-500 dark:text-zinc-400 text-lg max-w-md">
+								Você está offline e não possui instrumentos salvos em cache. Conecte-se à internet para carregar os instrumentos.
+							</p>
 						</div>
-					) : (
-						instrumentosData.map(instrumento => (
-							<Card key={instrumento.nome}>
-								<CardHeader>
-									<CardTitle className="flex items-center justify-center text-secondary">{instrumento.nome}
-									</CardTitle>
-									<CardDescription>
-									</CardDescription>
-								</CardHeader>
-							</Card>
-						))
-					)}
-				</div>
+					</Card>
+				) : (
+					<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+						{isLoading || !instrumentosData ? (
+							<div className="col-span-4 h-full flex items-center justify-center mt-20">
+								<div className="size-80 border-4 border-transparent text-primary/40 text-4xl animate-spin flex items-center justify-center border-t-primary rounded-full">
+									<div className="size-64 border-4 border-transparent text-subprimary/40 text-2xl animate-spin flex items-center justify-center border-t-subprimary rounded-full" />
+								</div>
+							</div>
+						) : (
+							instrumentosData.map(instrumento => (
+								<Card key={instrumento.nome}>
+									<CardHeader>
+										<CardTitle className="flex items-center justify-center text-secondary">{instrumento.nome}
+										</CardTitle>
+										<CardDescription>
+										</CardDescription>
+									</CardHeader>
+								</Card>
+							))
+						)}
+					</div>
+				)}
 			</main>
 			<AppSidebar side="right" />
 		</SidebarProvider >

--- a/src/app/home/levitas/page.tsx
+++ b/src/app/home/levitas/page.tsx
@@ -10,7 +10,7 @@ import {
 	CardTitle
 } from "@/components/ui/card";
 import { useEffect, useState } from "react";
-import { ListFilter, Trash2, UserMinus, X } from "lucide-react";
+import { ListFilter, Trash2, UserMinus, X, WifiOff } from "lucide-react";
 import { DialogAddLevita, DialogVerLevita } from "@/components/modals/dialog-levita";
 import { Input } from "@/components/ui/input";
 import { Levita, Instrumento } from "@/lib/apiObjects";
@@ -35,6 +35,23 @@ export default function LevitasPage() {
 	const [filteredLevitas, setFilteredLevita] = useState<Levita[] | undefined>(undefined)
 	const [isAdminOrLeader, setLeader] = useState(false)
 	const [loggedLevitaId, setLoggedLevitaId] = useState<string | null>(null)
+	const [isOffline, setIsOffline] = useState(false)
+
+	useEffect(() => {
+		const handleOnline = () => setIsOffline(false);
+		const handleOffline = () => setIsOffline(true);
+
+		if (typeof window !== 'undefined') {
+			setIsOffline(!navigator.onLine);
+			window.addEventListener('online', handleOnline);
+			window.addEventListener('offline', handleOffline);
+
+			return () => {
+				window.removeEventListener('online', handleOnline);
+				window.removeEventListener('offline', handleOffline);
+			};
+		}
+	}, []);
 
 	useEffect(() => {
 		if (sessionStorage.getItem("role") == "Líder" || sessionStorage.getItem("role") == "ADMIN") {
@@ -84,9 +101,15 @@ export default function LevitasPage() {
 				<div>
 					<div className="flex flex-wrap md:flex-nowrap justify-between items-center">
 						<div className="flex items-center justify-between w-full">
-							<div className="flex items-center">
+							<div className="flex items-center flex-wrap">
 								<BackButton />
 								<h1 className="ml-4 font-extrabold tracking-tight text-2xl sm:text-5xl">Levitas</h1>
+								{isOffline && Array.isArray(levitas) && levitas.length > 0 && (
+									<Badge variant="destructive" className="ml-4 mt-2 sm:mt-0 flex gap-1 items-center bg-red-500 hover:bg-red-600 cursor-default">
+										<WifiOff className="w-3 h-3" />
+										Dessincronizado
+									</Badge>
+								)}
 							</div>
 							<SidebarTrigger className="border md:hidden" />
 						</div>
@@ -142,112 +165,126 @@ export default function LevitasPage() {
 				</div>
 
 				{/* Content Grid */}
-				<div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6 lg:gap-8">
-					{isLoading ? (
-						<div className="col-span-full flex items-center justify-center py-16 sm:py-20">
-							<div className="size-32 sm:size-48 lg:size-80 border-4 border-transparent text-primary/40 animate-spin flex items-center justify-center border-t-primary rounded-full">
-								<div className="size-24 sm:size-36 lg:size-64 border-4 border-transparent text-subprimary/40 animate-spin flex items-center justify-center border-t-subprimary rounded-full" />
+				{isOffline && !levitas ? (
+					<Card className="text-center border-red-900/20 bg-red-500/5 mt-4">
+						<CardHeader className="items-center">
+							<WifiOff className="h-16 w-16 text-red-500/80 mb-4" />
+							<CardTitle className="text-2xl text-red-500">Sem Conexão</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<p className="text-zinc-500 dark:text-zinc-400 pb-6 text-lg px-4 md:px-10">
+								Você está offline e não possui levitas salvos em cache. Conecte-se à internet para visualizar os levitas.
+							</p>
+						</CardContent>
+					</Card>
+				) : (
+					<div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6 lg:gap-8">
+						{isLoading ? (
+							<div className="col-span-full flex items-center justify-center py-16 sm:py-20">
+								<div className="size-32 sm:size-48 lg:size-80 border-4 border-transparent text-primary/40 animate-spin flex items-center justify-center border-t-primary rounded-full">
+									<div className="size-24 sm:size-36 lg:size-64 border-4 border-transparent text-subprimary/40 animate-spin flex items-center justify-center border-t-subprimary rounded-full" />
+								</div>
 							</div>
-						</div>
-					) : filteredLevitas && filteredLevitas.length > 0 ? (
-						filteredLevitas.map(levita => (
-							<Card
-								key={levita.id}
-								className={`relative flex flex-col h-full lg:items-start hover:scale-[1.02] hover:shadow-lg transition-all ${removeOverlay ? "animate-pulse" : "duration-200"
-									} ${loggedLevitaId === levita.id ? "border-special/30 bg-special/10" : ""
-									}`}
-							>
-								<X className={removeOverlay ? "absolute hover:cursor-pointer sm:hidden bg-rose-500/80 rounded-br-xl p-1" : "absolute invisible"}
-									onClick={() => {
-										deleteMethod(`v1/levita/${levita.id}`)
-											.catch((error) => {
-												toast.error("Erro ao remover o Levita!")
-												console.error("Erro na comunicação com a api: ", error);
-											})
-											.finally(() => clearStates());
-									}}/>
-									<CardHeader className="pb-3 items-center text-center lg:items-start lg:text-start">
-										<CardTitle className={`text-base sm:text-lg ${Cookies.get("username") == levita.nome ? "text-special" : "text-primary"
-											} leading-tight`}>
-											{levita.nome}
-										</CardTitle>
-										<CardDescription className="text-xs sm:text-sm line-clamp-1">
-											<p className="sm:hidden">
-												{levita.contato ? levita.contato : levita.email.length > 18 ? levita.email.substring(0, 18) + "..." : levita.email}
-											</p>
-											<p className="hidden sm:block">
-												{levita.contato ? levita.contato : levita.email}
-											</p>
-										</CardDescription>
-									</CardHeader>
+						) : filteredLevitas && filteredLevitas.length > 0 ? (
+							filteredLevitas.map(levita => (
+								<Card
+									key={levita.id}
+									className={`relative flex flex-col h-full lg:items-start hover:scale-[1.02] hover:shadow-lg transition-all ${removeOverlay ? "animate-pulse" : "duration-200"
+										} ${loggedLevitaId === levita.id ? "border-special/30 bg-special/10" : ""
+										}`}
+								>
+									<X className={removeOverlay ? "absolute hover:cursor-pointer sm:hidden bg-rose-500/80 rounded-br-xl p-1" : "absolute invisible"}
+										onClick={() => {
+											deleteMethod(`v1/levita/${levita.id}`)
+												.catch((error) => {
+													toast.error("Erro ao remover o Levita!")
+													console.error("Erro na comunicação com a api: ", error);
+												})
+												.finally(() => clearStates());
+										}}/>
+										<CardHeader className="pb-3 items-center text-center lg:items-start lg:text-start">
+											<CardTitle className={`text-base sm:text-lg ${Cookies.get("username") == levita.nome ? "text-special" : "text-primary"
+												} leading-tight`}>
+												{levita.nome}
+											</CardTitle>
+											<CardDescription className="text-xs sm:text-sm line-clamp-1">
+												<p className="sm:hidden">
+													{levita.contato ? levita.contato : levita.email.length > 18 ? levita.email.substring(0, 18) + "..." : levita.email}
+												</p>
+												<p className="hidden sm:block">
+													{levita.contato ? levita.contato : levita.email}
+												</p>
+											</CardDescription>
+										</CardHeader>
 
-									<CardContent className="flex-1 pb-3 space-y-3 w-full">
-										{/* Instruments Carousel */}
-										<div className="min-h-[2rem]">
-											{levita.instrumentos.length > 0 ? (
-												<Carousel className="w-fit max-w-[140px] sm:max-w-48 lg:w-full lg:justify-self-start justify-self-center">
-													<CarouselContent className="-ml-1">
-														{levita.instrumentos.sort((a, b) => a.id - b.id).map(instrumento => (
-															<CarouselItem key={instrumento.id} className="basis-auto pl-1">
-																<Badge variant="outline" className="text-xs whitespace-nowrap">
-																	{instrumento.nome}
-																</Badge>
-															</CarouselItem>
-														))}
-													</CarouselContent>
-												</Carousel>
-											) : (
-												<p className="text-xs text-muted-foreground">Sem instrumentos</p>
-											)}
-										</div>
+										<CardContent className="flex-1 pb-3 space-y-3 w-full">
+											{/* Instruments Carousel */}
+											<div className="min-h-[2rem]">
+												{levita.instrumentos.length > 0 ? (
+													<Carousel className="w-fit max-w-[140px] sm:max-w-48 lg:w-full lg:justify-self-start justify-self-center">
+														<CarouselContent className="-ml-1">
+															{levita.instrumentos.sort((a, b) => a.id - b.id).map(instrumento => (
+																<CarouselItem key={instrumento.id} className="basis-auto pl-1">
+																	<Badge variant="outline" className="text-xs whitespace-nowrap">
+																		{instrumento.nome}
+																	</Badge>
+																</CarouselItem>
+															))}
+														</CarouselContent>
+													</Carousel>
+												) : (
+													<p className="text-xs text-muted-foreground">Sem instrumentos</p>
+												)}
+											</div>
 
-										{/* Description */}
-										<div className="min-h-[3rem] sm:min-h-[4rem] justify-self-center">
-											{levita.descricao ? (
-												<CardDescription className="text-xs sm:text-sm text-subprimary line-clamp-3">
-													{levita.descricao}
-												</CardDescription>
-											) : (
-												<CardDescription className="text-xs sm:text-sm line-clamp-3">
-													Levita sem descrição.
-												</CardDescription>
-											)}
-										</div>
-									</CardContent>
+											{/* Description */}
+											<div className="min-h-[3rem] sm:min-h-[4rem] justify-self-center">
+												{levita.descricao ? (
+													<CardDescription className="text-xs sm:text-sm text-subprimary line-clamp-3">
+														{levita.descricao}
+													</CardDescription>
+												) : (
+													<CardDescription className="text-xs sm:text-sm line-clamp-3">
+														Levita sem descrição.
+													</CardDescription>
+												)}
+											</div>
+										</CardContent>
 
-									<CardFooter className="pt-3 justify-between w-full">
-										<DialogVerLevita
-											key={levita.id}
-											levita={levita}
-											disabled={removeOverlay}
-											setLevitas={setLevitas}
-										/>
-										<Button variant={"destructive"} size={"sm"} disabled={!removeOverlay || isLoading}
-											className={`transition-all duration-200 ease-in-out hidden sm:block ${removeOverlay ? "hover:cursor-pointer animate-none" : "invisible"}`}
-											onClick={() => {
-												deleteMethod(`v1/levita/${levita.id}`)
-													.catch((error) => {
-														toast.error("Erro ao remover o Levita!")
-														console.error("Erro na comunicação com a api: ", error);
-													})
-													.finally(() => clearStates());
-											}}>
-											<Trash2 />
-										</Button>
-									</CardFooter>
-							</Card>
-						))
-					) : (
-						<div className="col-span-full flex flex-col items-center justify-center py-16 sm:py-20 text-center">
-							<p className="text-lg sm:text-xl text-muted-foreground mb-2">
-								Nenhum levita encontrado
-							</p>
-							<p className="text-sm text-muted-foreground mx-8">
-								Tente ajustar os filtros ou buscar por outro nome.
-							</p>
-						</div>
-					)}
-				</div>
+										<CardFooter className="pt-3 justify-between w-full">
+											<DialogVerLevita
+												key={levita.id}
+												levita={levita}
+												disabled={removeOverlay}
+												setLevitas={setLevitas}
+											/>
+											<Button variant={"destructive"} size={"sm"} disabled={!removeOverlay || isLoading}
+												className={`transition-all duration-200 ease-in-out hidden sm:block ${removeOverlay ? "hover:cursor-pointer animate-none" : "invisible"}`}
+												onClick={() => {
+													deleteMethod(`v1/levita/${levita.id}`)
+														.catch((error) => {
+															toast.error("Erro ao remover o Levita!")
+															console.error("Erro na comunicação com a api: ", error);
+														})
+														.finally(() => clearStates());
+												}}>
+												<Trash2 />
+											</Button>
+										</CardFooter>
+								</Card>
+							))
+						) : (
+							<div className="col-span-full flex flex-col items-center justify-center py-16 sm:py-20 text-center">
+								<p className="text-lg sm:text-xl text-muted-foreground mb-2">
+									Nenhum levita encontrado
+								</p>
+								<p className="text-sm text-muted-foreground mx-8">
+									Tente ajustar os filtros ou buscar por outro nome.
+								</p>
+							</div>
+						)}
+					</div>
+				)}
 			</main>
 			<AppSidebar side="right" />
 		</SidebarProvider>

--- a/src/app/home/musicas/page.tsx
+++ b/src/app/home/musicas/page.tsx
@@ -8,10 +8,11 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
-import { ChevronLeft } from "lucide-react";
+import { ChevronLeft, WifiOff } from "lucide-react";
 import { TbMusicX } from "react-icons/tb";
 import Link from "next/link";
 import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
 import { useEffect, useState } from "react";
 import { Musica } from "@/lib/apiObjects";
 import { DialogAddMusica } from "@/components/modals/dialog-musica";
@@ -29,6 +30,23 @@ export default function Home() {
 	const [searchItem, setSearchItem] = useState("");
 	const [update, setUpdate] = useState(false)
 	const [isLeader, setLeader] = useState(false)
+	const [isOffline, setIsOffline] = useState(false)
+
+	useEffect(() => {
+		const handleOnline = () => setIsOffline(false);
+		const handleOffline = () => setIsOffline(true);
+
+		if (typeof window !== 'undefined') {
+			setIsOffline(!navigator.onLine);
+			window.addEventListener('online', handleOnline);
+			window.addEventListener('offline', handleOffline);
+
+			return () => {
+				window.removeEventListener('online', handleOnline);
+				window.removeEventListener('offline', handleOffline);
+			};
+		}
+	}, []);
 
 	useEffect(() => {
 		if (sessionStorage.getItem("role") == "Líder" || sessionStorage.getItem("role") == "ADMIN") {
@@ -60,9 +78,15 @@ export default function Home() {
 				<nav className="mb-4">
 					<div className="flex items-center mb-4 gap-4 justify-between align-middle">
 						<div className="flex items-center justify-between w-full">
-							<div className="flex items-center">
+							<div className="flex items-center flex-wrap">
 								<BackButton />
 								<h1 className="ml-4 font-extrabold tracking-tight text-2xl sm:text-5xl">Músicas</h1>
+								{isOffline && Array.isArray(musicas) && musicas.length > 0 && (
+									<Badge variant="destructive" className="ml-4 mt-2 sm:mt-0 flex gap-1 items-center bg-red-500 hover:bg-red-600 cursor-default">
+										<WifiOff className="w-3 h-3" />
+										Dessincronizado
+									</Badge>
+								)}
 							</div>
 							<SidebarTrigger className="border sm:hidden" />
 						</div>
@@ -77,7 +101,17 @@ export default function Home() {
 						value={searchItem} onChange={(e) => setSearchItem(e.target.value)} placeholder="Procurar por uma música." />
 				</div>
 
-				{isLoading ? (
+				{isOffline && !musicas ? (
+					<Card className="text-center border-red-900/20 bg-red-500/5 mt-4">
+						<div className="p-6 sm:p-10 flex flex-col items-center">
+							<WifiOff className="h-16 w-16 text-red-500/80 mb-4" />
+							<h3 className="text-2xl text-red-500 font-bold mb-2">Sem Conexão</h3>
+							<p className="text-zinc-500 dark:text-zinc-400 text-lg max-w-md">
+								Você está offline e não possui músicas salvas em cache. Conecte-se à internet para carregar a lista de músicas.
+							</p>
+						</div>
+					</Card>
+				) : isLoading ? (
 					<div className="col-span-4 h-full w-full flex items-center justify-center mt-20">
 						<div className="size-80 border-4 border-transparent text-primary/40 text-4xl animate-spin flex items-center justify-center border-t-primary rounded-full">
 							<div className="size-64 border-4 border-transparent text-subprimary/40 text-2xl animate-spin flex items-center justify-center border-t-subprimary rounded-full" />

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -12,19 +12,40 @@ import { AppSidebar } from "@/components/app-sidebar";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import compareDates from "@/util/compareDates";
 import BackButton from "@/components/next-back";
+import { Badge } from "@/components/ui/badge";
+import { WifiOff } from "lucide-react";
 
 export default function Home() {
 
     const [nextEscalas, setNextEscalas] = useState<EscalaResumida[] | undefined>(undefined)
     const [levitasData, setLevitasData] = useState<Levita[] | undefined>(undefined)
     const [isClient, setIsClient] = useState(false)
+    const [isOffline, setIsOffline] = useState(false)
 
     useEffect(() => {
         setIsClient(true)
+        
+        const handleOnline = () => setIsOffline(false);
+        const handleOffline = () => setIsOffline(true);
+
+        if (typeof window !== 'undefined') {
+            setIsOffline(!navigator.onLine);
+            window.addEventListener('online', handleOnline);
+            window.addEventListener('offline', handleOffline);
+
+            return () => {
+                window.removeEventListener('online', handleOnline);
+                window.removeEventListener('offline', handleOffline);
+            };
+        }
+    }, [])
+
+    useEffect(() => {
+        if (!isClient) return;
         if (nextEscalas) return;
         getMethod<EscalaResumida[] | undefined>("v1/escala/resumed", setNextEscalas)
         getMethod<Levita[] | undefined>("v1/levita/resumed", setLevitasData)
-    }, [])
+    }, [isClient, nextEscalas])
 
     return (
         <SidebarProvider defaultOpen>
@@ -32,11 +53,17 @@ export default function Home() {
             <main className="flex-1 w-full max-w-3xl xl:max-w-6xl max-h-screen mx-auto p-4 sm:p-6 lg:p-8 space-y-6">
                 <nav className="space-y-4">
                     <div className="flex justify-between items-center">
-                        <div className="flex items-center gap-3 sm:gap-4">
+                        <div className="flex items-center gap-3 sm:gap-4 flex-wrap">
                             <BackButton />
                             <h1 className="font-extrabold tracking-tight text-2xl sm:text-3xl md:text-4xl lg:text-5xl truncate">
                                 Planejador
                             </h1>
+                            {isOffline && ((nextEscalas && nextEscalas.length > 0) || (levitasData && levitasData.length > 0)) && (
+                                <Badge variant="destructive" className="ml-2 sm:ml-4 flex gap-1 items-center bg-red-500 hover:bg-red-600 cursor-default">
+                                    <WifiOff className="w-3 h-3" />
+                                    Dessincronizado
+                                </Badge>
+                            )}
                         </div>
                         <SidebarTrigger className="border md:hidden" />
                     </div>
@@ -68,102 +95,114 @@ export default function Home() {
                 </div>
 
                 <div className="space-y-6">
-                    <Card className="p-3 sm:p-6 lg:p-8 bg-current/30">
-                        {/* Próximas Escalas Section */}
-                        <Card className="p-3 sm:p-4 mb-6">
-                            <CardTitle className="text-primary p-3 sm:p-4 text-lg sm:text-xl">
-                                Próximas Escalas:
-                            </CardTitle>
-
-                            {!isClient || !nextEscalas ? (
-                                <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4 px-4 py-4">
-                                    <Skeleton className="h-40 w-full rounded-lg" />
-                                    <Skeleton className="h-40 w-full rounded-lg hidden sm:block" />
-                                    <Skeleton className="h-40 w-full rounded-lg hidden xl:block" />
-                                </div>
-                            ) : nextEscalas.length > 0 ? (
-                                <div className="px-2 sm:px-4">
-                                    <Carousel className="w-full">
-                                        <CarouselContent className="-ml-2 sm:-ml-1">
-                                            {nextEscalas.sort((a, b) => {
-                                                const today = new Date();
-                                                const dateA = new Date(a.data);
-                                                const dateB = new Date(b.data);
-                                                const isPastA = compareDates(a.data, today);
-                                                const isPastB = compareDates(b.data, today);
-
-                                                if (isPastA && !isPastB) return 1;
-                                                if (!isPastA && isPastB) return -1;
-
-                                                return dateA.getTime() - dateB.getTime();
-                                            }).map(escala => (
-                                                <CarouselItem key={escala.id} className="pl-2 sm:pl-1 basis-full sm:basis-1/2 xl:basis-1/3 select-none">
-                                                    <div className="p-1">
-                                                        <EscalaSimpleCard
-                                                            key={escala.id}
-                                                            escala={escala}
-                                                        />
-                                                    </div>
-                                                </CarouselItem>
-                                            ))}
-                                        </CarouselContent>
-                                        <div className="hidden sm:flex">
-                                            <CarouselPrevious className="ml-4" />
-                                            <CarouselNext className="mr-4" />
-                                        </div>
-                                    </Carousel>
-                                </div>
-                            ) : (
-                                <div className="px-4 py-8 text-center">
-                                    <p className="text-neutral-600 text-sm sm:text-base">
-                                        Nenhuma escala cadastrada para os próximos dias.
-                                    </p>
-                                </div>
-                            )}
+                    {isOffline && !nextEscalas && !levitasData ? (
+                        <Card className="text-center border-red-900/20 bg-red-500/5 mt-4">
+                            <div className="p-6 sm:p-10 flex flex-col items-center">
+                                <WifiOff className="h-16 w-16 text-red-500/80 mb-4" />
+                                <h3 className="text-2xl text-red-500 font-bold mb-2">Sem Conexão</h3>
+                                <p className="text-zinc-500 dark:text-zinc-400 text-lg max-w-md">
+                                    Você está offline e não possui dados salvos no planejador. Conecte-se à internet para carregar as escalas e levitas.
+                                </p>
+                            </div>
                         </Card>
+                    ) : (
+                        <Card className="p-3 sm:p-6 lg:p-8 bg-current/30">
+                            {/* Próximas Escalas Section */}
+                            <Card className="p-3 sm:p-4 mb-6">
+                                <CardTitle className="text-primary p-3 sm:p-4 text-lg sm:text-xl">
+                                    Próximas Escalas:
+                                </CardTitle>
 
-                        {/* Levitas Section */}
-                        <Card className="p-3 sm:p-4">
-                            <CardTitle className="text-primary p-3 sm:p-4 text-lg sm:text-xl">
-                                Levitas Cadastrados:
-                            </CardTitle>
+                                {!isClient || !nextEscalas ? (
+                                    <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4 px-4 py-4">
+                                        <Skeleton className="h-40 w-full rounded-lg" />
+                                        <Skeleton className="h-40 w-full rounded-lg hidden sm:block" />
+                                        <Skeleton className="h-40 w-full rounded-lg hidden xl:block" />
+                                    </div>
+                                ) : nextEscalas.length > 0 ? (
+                                    <div className="px-2 sm:px-4">
+                                        <Carousel className="w-full">
+                                            <CarouselContent className="-ml-2 sm:-ml-1">
+                                                {nextEscalas.sort((a, b) => {
+                                                    const today = new Date();
+                                                    const dateA = new Date(a.data);
+                                                    const dateB = new Date(b.data);
+                                                    const isPastA = compareDates(a.data, today);
+                                                    const isPastB = compareDates(b.data, today);
 
-                            {!isClient || !levitasData ? (
-                                <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4 px-4 py-4">
-                                    <Skeleton className="h-40 w-full rounded-lg" />
-                                    <Skeleton className="h-40 w-full rounded-lg hidden sm:block" />
-                                    <Skeleton className="h-40 w-full rounded-lg hidden xl:block" />
-                                </div>
-                            ) : levitasData.length > 0 ? (
-                                <div className="px-2 sm:px-4">
-                                    <Carousel className="w-full">
-                                        <CarouselContent className="-ml-2 sm:-ml-1">
-                                            {levitasData.map(levita => (
-                                                <CarouselItem key={levita.id} className="pl-2 sm:pl-1 basis-full sm:basis-1/2 xl:basis-1/3 select-none">
-                                                    <div className="p-1">
-                                                        <LevitaSimpleCard
-                                                            key={levita.id}
-                                                            levita={levita}
-                                                        />
-                                                    </div>
-                                                </CarouselItem>
-                                            ))}
-                                        </CarouselContent>
-                                        <div className="hidden sm:flex">
-                                            <CarouselPrevious className="ml-4" />
-                                            <CarouselNext className="mr-4" />
-                                        </div>
-                                    </Carousel>
-                                </div>
-                            ) : (
-                                <div className="px-4 py-8 text-center">
-                                    <p className="text-neutral-600 text-sm sm:text-base">
-                                        Nenhum levita encontrado!
-                                    </p>
-                                </div>
-                            )}
+                                                    if (isPastA && !isPastB) return 1;
+                                                    if (!isPastA && isPastB) return -1;
+
+                                                    return dateA.getTime() - dateB.getTime();
+                                                }).map(escala => (
+                                                    <CarouselItem key={escala.id} className="pl-2 sm:pl-1 basis-full sm:basis-1/2 xl:basis-1/3 select-none">
+                                                        <div className="p-1">
+                                                            <EscalaSimpleCard
+                                                                key={escala.id}
+                                                                escala={escala}
+                                                            />
+                                                        </div>
+                                                    </CarouselItem>
+                                                ))}
+                                            </CarouselContent>
+                                            <div className="hidden sm:flex">
+                                                <CarouselPrevious className="ml-4" />
+                                                <CarouselNext className="mr-4" />
+                                            </div>
+                                        </Carousel>
+                                    </div>
+                                ) : (
+                                    <div className="px-4 py-8 text-center">
+                                        <p className="text-neutral-600 text-sm sm:text-base">
+                                            Nenhuma escala cadastrada para os próximos dias.
+                                        </p>
+                                    </div>
+                                )}
+                            </Card>
+
+                            {/* Levitas Section */}
+                            <Card className="p-3 sm:p-4">
+                                <CardTitle className="text-primary p-3 sm:p-4 text-lg sm:text-xl">
+                                    Levitas Cadastrados:
+                                </CardTitle>
+
+                                {!isClient || !levitasData ? (
+                                    <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4 px-4 py-4">
+                                        <Skeleton className="h-40 w-full rounded-lg" />
+                                        <Skeleton className="h-40 w-full rounded-lg hidden sm:block" />
+                                        <Skeleton className="h-40 w-full rounded-lg hidden xl:block" />
+                                    </div>
+                                ) : levitasData.length > 0 ? (
+                                    <div className="px-2 sm:px-4">
+                                        <Carousel className="w-full">
+                                            <CarouselContent className="-ml-2 sm:-ml-1">
+                                                {levitasData.map(levita => (
+                                                    <CarouselItem key={levita.id} className="pl-2 sm:pl-1 basis-full sm:basis-1/2 xl:basis-1/3 select-none">
+                                                        <div className="p-1">
+                                                            <LevitaSimpleCard
+                                                                key={levita.id}
+                                                                levita={levita}
+                                                            />
+                                                        </div>
+                                                    </CarouselItem>
+                                                ))}
+                                            </CarouselContent>
+                                            <div className="hidden sm:flex">
+                                                <CarouselPrevious className="ml-4" />
+                                                <CarouselNext className="mr-4" />
+                                            </div>
+                                        </Carousel>
+                                    </div>
+                                ) : (
+                                    <div className="px-4 py-8 text-center">
+                                        <p className="text-neutral-600 text-sm sm:text-base">
+                                            Nenhum levita encontrado!
+                                        </p>
+                                    </div>
+                                )}
+                            </Card>
                         </Card>
-                    </Card>
+                    )}
                 </div>
             </main>
         </SidebarProvider>


### PR DESCRIPTION
This pull request adds robust offline detection and user feedback across multiple pages of the application. Now, when the user is offline, each relevant page will display a clear warning badge if cached data is available, or a dedicated "offline" message if no data is cached. This improves the user experience by making connectivity issues explicit and guiding users on what to do next.

**Offline detection and user feedback improvements:**

* Added an `isOffline` state with online/offline event listeners to all main pages (`page.tsx` for escalas, instrumentos, levitas, musicas, and the home dashboard) to track network status and update the UI accordingly. 
* When offline and cached data is present, a red "Dessincronizado" badge with a `WifiOff` icon is shown in the page header for escalas, instrumentos, levitas, musicas, and the dashboard. 
* If the user is offline and no cached data is available, a prominent card with a `WifiOff` icon and an explanatory message is displayed, informing the user that they need to connect to the internet to view or load data. This is implemented for escalas, instrumentos, levitas, musicas, and the dashboard. 

**UI consistency and code improvements:**

* Updated header layouts to use `flex-wrap` for better responsiveness when the offline badge appears. 
* Imported `Badge` and `WifiOff` components where needed to support the new UI elements. 

These changes ensure users are always aware of their connectivity status and the availability of cached data, reducing confusion and improving reliability.